### PR TITLE
Change Makefile from scratch to autoconf/automake

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,26 @@
+AUTOMAKE_OPTIONS = foreign
+ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
+
+bin_PROGRAMS = usb-12key-kbd-prog
+
+usb_12key_kbd_prog_SOURCES = \
+	usb-12key-kbd-prog.c \
+	scancode.c
+
+# options
+# Additional library
+usb_12key_kbd_prog_LDADD = \
+	@LIBUSB10_LIBS@
+
+# C compiler options
+usb_12key_kbd_prog_CFLAGS = \
+	-Os -Wall \
+	@LIBUSB10_CFLAGS@
+
+# C++ compiler options
+usb_12key_kbd_prog_CXXFLAGS = \
+	-Os -Wall \
+	@LIBUSB10_CFLAGS@
+
+# Linker options
+usb_12key_kbd_prog_LDFLAGS = 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ This command line tool is to program 6/9/12 Bluetooth/USB keyboard:
     - (Linux/debian etc.) apt install libusb-1.0-0-dev
     - (Linux/fedora etc.) dnf install libusb1-devel
 - make
-    - `#include` in .c file maybe modified to `<libusb-1.0/libusb.h>` in Linux
+```
+./autogen.h
+make
+make install
+```
 
 ## Usage
 ```

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+test -n "$srcdir" || srcdir=`dirname "$0"`
+test -n "$srcdir" || srcdir=.
+(
+  cd "$srcdir" &&
+  autoreconf --force -v --install
+) || exit
+test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,30 @@
+# autoconf for usb-12key-kbd-prog
+
+AC_PREREQ([2.69])
+
+AC_INIT([usb-12key-kbd-prog], [1.0])
+
+AM_INIT_AUTOMAKE([foreign])
+
+AC_CONFIG_SRCDIR([usb-12key-kbd-prog.c])
+AC_CONFIG_HEADERS([config.h])
+
+AC_CONFIG_MACRO_DIR([m4])
+
+# Checks for programs.
+AC_PROG_CC
+AC_PROG_CXX
+AC_PROG_INSTALL
+
+AC_DISABLE_STATIC
+
+# Checks for libraries.
+LT_INIT
+#AM_PROG_LIBTOOL 
+
+PKG_PROG_PKG_CONFIG
+PKG_CHECK_MODULES([LIBUSB10], [libusb-1.0])
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
+

--- a/key-setup-cluster.sh
+++ b/key-setup-cluster.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+
+echo off
+echo "Key Map"
+echo "-------------   -------- "
+echo "| 7 | 4 | 1 |  |13,14,15|"
+echo "-------------   -------- "
+echo "| 8 | 5 | 2 |            "
+echo "-------------   -------- "
+echo "| 9 | 6 | 3 |  |16,17,18|"
+echo "-------------   -------- "
+echo ""
+
+./usb-12key-kbd-prog 2 1 F1
+./usb-12key-kbd-prog 2 2 F2
+./usb-12key-kbd-prog 2 3 F3
+./usb-12key-kbd-prog 2 4 F4
+./usb-12key-kbd-prog 2 5 F5
+./usb-12key-kbd-prog 2 6 F6
+./usb-12key-kbd-prog 2 7 F7
+./usb-12key-kbd-prog 2 8 F8
+./usb-12key-kbd-prog 2 9 F9
+./usb-12key-kbd-prog 2 13 F13
+./usb-12key-kbd-prog 2 14 F14
+./usb-12key-kbd-prog 2 15 F15
+./usb-12key-kbd-prog 2 16 F16
+./usb-12key-kbd-prog 2 17 F17
+./usb-12key-kbd-prog 2 18 F18
+
+echo "L2: AGL cluster ui setting"
+echo "-------------   -------- "
+echo "| 7 | 4 | 1 |  |13,14,15|"
+echo "-------------   -------- "
+echo "| 8 | 5 | 2 |            "
+echo "-------------   -------- "
+echo "| 9 | 6 | 3 |  |16,17,18|"
+echo "-------------   -------- "
+echo "These number X are FX key."
+echo ""
+

--- a/key-setup-momikey.sh
+++ b/key-setup-momikey.sh
@@ -13,13 +13,13 @@ echo ""
 
 ./usb-12key-kbd-prog 1 1 d
 ./usb-12key-kbd-prog 1 2 b
-./usb-12key-kbd-prog 1 3 3
+./usb-12key-kbd-prog 1 3 v
 ./usb-12key-kbd-prog 1 4 s
 ./usb-12key-kbd-prog 1 5 a
-./usb-12key-kbd-prog 1 6 2
+./usb-12key-kbd-prog 1 6 x
 ./usb-12key-kbd-prog 1 7 g
 ./usb-12key-kbd-prog 1 8 h
-./usb-12key-kbd-prog 1 9 1
+./usb-12key-kbd-prog 1 9 z
 ./usb-12key-kbd-prog 1 13 n
 ./usb-12key-kbd-prog 1 14 c
 ./usb-12key-kbd-prog 1 15 n
@@ -33,7 +33,7 @@ echo "| g | s | d |  | n, c, n|"
 echo "-------------   -------- "
 echo "| h | a | b |            "
 echo "-------------   -------- "
-echo "| 1 | 2 | 3 |  | n, n, n|"
+echo "| z | x | v|  | n, n, n|"
 echo "-------------   -------- "
 echo "g : AGL Flutter demo IVI CES2024"
 echo "s : AGL Flutter demo IVI CES2023"
@@ -42,7 +42,7 @@ echo "h : AGL HTML5 demo IVI"
 echo "a : AGL Momi demo IVI"
 echo "b : AGL Safe Momi demo IVI"
 echo "c : force reboot guest"
-echo "1: Teltail 1"
-echo "2: Teltail 2"
-echo "3: Teltail 3"
+echo "z : Teltail 1"
+echo "x : Teltail 2"
+echo "v : Teltail 3"
 echo ""

--- a/key-setup-momikey.sh
+++ b/key-setup-momikey.sh
@@ -1,0 +1,43 @@
+#! /bin/sh
+
+echo off
+echo "Key Map"
+echo "-------------   -------- "
+echo "| 7 | 4 | 1 |  |13,14,15|"
+echo "-------------   -------- "
+echo "| 8 | 5 | 2 |            "
+echo "-------------   -------- "
+echo "| 9 | 6 | 3 |  |16,17,18|"
+echo "-------------   -------- "
+echo ""
+
+./usb-12key-kbd-prog 1 1 n
+./usb-12key-kbd-prog 1 2 n
+./usb-12key-kbd-prog 1 3 c
+./usb-12key-kbd-prog 1 4 h
+./usb-12key-kbd-prog 1 5 n
+./usb-12key-kbd-prog 1 6 n
+./usb-12key-kbd-prog 1 7 g
+./usb-12key-kbd-prog 1 8 d
+./usb-12key-kbd-prog 1 9 a
+./usb-12key-kbd-prog 1 13 n
+./usb-12key-kbd-prog 1 14 n
+./usb-12key-kbd-prog 1 15 n
+./usb-12key-kbd-prog 1 16 n
+./usb-12key-kbd-prog 1 17 n
+./usb-12key-kbd-prog 1 18 n
+
+echo "AGL momikey setting"
+echo "-------------   -------- "
+echo "| g | h | n |  | n, n, n|"
+echo "-------------   -------- "
+echo "| d | n | 2 |            "
+echo "-------------   -------- "
+echo "| a | n | c |  | n, n, n|"
+echo "-------------   -------- "
+echo "g : agl-flutter-ivi-demo"
+echo "d : agl-qt-ivi-demo"
+echo "a : agl-momi-ivi-demo"
+echo "h : agl-html5-ivi-demo"
+echo "c : force reboot guest"
+echo ""

--- a/key-setup-momikey.sh
+++ b/key-setup-momikey.sh
@@ -13,13 +13,13 @@ echo ""
 
 ./usb-12key-kbd-prog 1 1 d
 ./usb-12key-kbd-prog 1 2 b
-./usb-12key-kbd-prog 1 3 F3
+./usb-12key-kbd-prog 1 3 3
 ./usb-12key-kbd-prog 1 4 s
 ./usb-12key-kbd-prog 1 5 a
-./usb-12key-kbd-prog 1 6 F2
+./usb-12key-kbd-prog 1 6 2
 ./usb-12key-kbd-prog 1 7 g
 ./usb-12key-kbd-prog 1 8 h
-./usb-12key-kbd-prog 1 9 F1
+./usb-12key-kbd-prog 1 9 1
 ./usb-12key-kbd-prog 1 13 n
 ./usb-12key-kbd-prog 1 14 c
 ./usb-12key-kbd-prog 1 15 n
@@ -33,7 +33,7 @@ echo "| g | s | d |  | n, c, n|"
 echo "-------------   -------- "
 echo "| h | a | b |            "
 echo "-------------   -------- "
-echo "| F1| F2| F3|  | n, n, n|"
+echo "| 1 | 2 | 3 |  | n, n, n|"
 echo "-------------   -------- "
 echo "g : AGL Flutter demo IVI CES2024"
 echo "s : AGL Flutter demo IVI CES2023"
@@ -42,7 +42,7 @@ echo "h : AGL HTML5 demo IVI"
 echo "a : AGL Momi demo IVI"
 echo "b : AGL Safe Momi demo IVI"
 echo "c : force reboot guest"
-echo "F1: Teltail 1"
-echo "F2: Teltail 2"
-echo "F3: Teltail 3"
+echo "1: Teltail 1"
+echo "2: Teltail 2"
+echo "3: Teltail 3"
 echo ""

--- a/key-setup-momikey.sh
+++ b/key-setup-momikey.sh
@@ -11,17 +11,17 @@ echo "| 9 | 6 | 3 |  |16,17,18|"
 echo "-------------   -------- "
 echo ""
 
-./usb-12key-kbd-prog 1 1 n
-./usb-12key-kbd-prog 1 2 n
-./usb-12key-kbd-prog 1 3 c
-./usb-12key-kbd-prog 1 4 h
-./usb-12key-kbd-prog 1 5 n
-./usb-12key-kbd-prog 1 6 n
+./usb-12key-kbd-prog 1 1 d
+./usb-12key-kbd-prog 1 2 b
+./usb-12key-kbd-prog 1 3 F3
+./usb-12key-kbd-prog 1 4 s
+./usb-12key-kbd-prog 1 5 a
+./usb-12key-kbd-prog 1 6 F2
 ./usb-12key-kbd-prog 1 7 g
-./usb-12key-kbd-prog 1 8 d
-./usb-12key-kbd-prog 1 9 a
+./usb-12key-kbd-prog 1 8 h
+./usb-12key-kbd-prog 1 9 F1
 ./usb-12key-kbd-prog 1 13 n
-./usb-12key-kbd-prog 1 14 n
+./usb-12key-kbd-prog 1 14 c
 ./usb-12key-kbd-prog 1 15 n
 ./usb-12key-kbd-prog 1 16 n
 ./usb-12key-kbd-prog 1 17 n
@@ -29,15 +29,20 @@ echo ""
 
 echo "AGL momikey setting"
 echo "-------------   -------- "
-echo "| g | h | n |  | n, n, n|"
+echo "| g | s | d |  | n, c, n|"
 echo "-------------   -------- "
-echo "| d | n | 2 |            "
+echo "| h | a | b |            "
 echo "-------------   -------- "
-echo "| a | n | c |  | n, n, n|"
+echo "| F1| F2| F3|  | n, n, n|"
 echo "-------------   -------- "
-echo "g : agl-flutter-ivi-demo"
-echo "d : agl-qt-ivi-demo"
-echo "a : agl-momi-ivi-demo"
-echo "h : agl-html5-ivi-demo"
+echo "g : AGL Flutter demo IVI CES2024"
+echo "s : AGL Flutter demo IVI CES2023"
+echo "d : AGL Qt demo IVI"
+echo "h : AGL HTML5 demo IVI"
+echo "a : AGL Momi demo IVI"
+echo "b : AGL Safe Momi demo IVI"
 echo "c : force reboot guest"
+echo "F1: Teltail 1"
+echo "F2: Teltail 2"
+echo "F3: Teltail 3"
 echo ""


### PR DESCRIPTION
Fixed build error in Linux environment. My environment is Ubuntu 20.04.
This change use autoconf/automake tool to adjust link order with pkg-config.  On the other hand, this patch did not test building in Mac OS environment, only tested linux.